### PR TITLE
Add C/C++ and Python specific styles

### DIFF
--- a/index.less
+++ b/index.less
@@ -5,6 +5,8 @@
 @import "markdown";
 @import "css";
 @import "ruby";
+@import "python";
+@import "c";
 @import "terminal";
 @import "git-diff";
 @import "wrap-guide";

--- a/stylesheets/c.less
+++ b/stylesheets/c.less
@@ -1,0 +1,28 @@
+.source.c, .source.c\+\+ {
+  .meta.preprocessor {
+    color: @red;
+  }
+  .keyword.control.import {
+    color: @red;
+  }
+  .punctuation.string {
+    color: @cyan;
+  }
+  .constant {
+    color: @red;
+
+    &.numeric {
+      color: @cyan;
+    }
+  }
+  .storage {
+    color: @yellow;
+  }
+  .entity {
+    color: @base0;
+
+    &.name.function.preprocessor {
+      color: @red;
+    }
+  }
+}

--- a/stylesheets/python.less
+++ b/stylesheets/python.less
@@ -1,0 +1,24 @@
+.source.python {
+  .entity {
+    color: @base0;
+
+    &.name {
+      color: @blue;
+    }
+  }
+  .punctuation.string {
+    color: @cyan;
+  }
+  .keyword.operator {
+    color: @base0;
+  }
+  .constant.other {
+    color: @red;
+  }
+  .keyword.control.import {
+    color: @red;
+  }
+  .variable {
+    color: @base0;
+  }
+}


### PR DESCRIPTION
Add C/C++ and Python specific styles (to be a little closer to vim solarized theme)
![c](https://cloud.githubusercontent.com/assets/6019000/3141938/72593db8-e9a1-11e3-8334-e1ddf0dfd7c6.png)
![python](https://cloud.githubusercontent.com/assets/6019000/3141939/727e7916-e9a1-11e3-9c05-482f2e6c8ae4.png)
