### PR TITLE
Update C/C++ and Python specific styles

### DIFF
--- a/stylesheets/c.less
+++ b/stylesheets/c.less
@@ -11,7 +11,7 @@
   .constant {
     color: @red;
 
-    &.numeric {
+    &.numeric, &.language.c {
       color: @cyan;
     }
   }
@@ -22,6 +22,21 @@
     color: @base0;
 
     &.name.function.preprocessor {
+      color: @red;
+    }
+  }
+  .support.type {
+    color: @yellow;
+
+    &.posix-reserved {
+      color: @base0;
+    }
+  }
+  .variable {
+    &.other.dot-access {
+      color: @base0;
+    }
+    &.parameter.preprocessor {
       color: @red;
     }
   }

--- a/stylesheets/python.less
+++ b/stylesheets/python.less
@@ -24,6 +24,9 @@
     }
     &.other {
       color: @blue;
+      &.python {
+        color: @green;
+      }
     }
   }
   .constant {
@@ -44,8 +47,13 @@
     &.function.builtin {
       color: @blue;
     }
-    &.type.exception {
-      color: @yellow;
+    &.type {
+      &.exception.python {
+        color: @yellow;
+      }
+      &.python {
+        color: @blue;
+      }
     }
   }
   .storage.type.string {


### PR DESCRIPTION
Update C/C++ and Python specific styles in order to look more like Solarized theme for Vim
### C/C++

![capture decran 2014-06-21 a 14 11 35](https://cloud.githubusercontent.com/assets/6019000/3348805/13d9381e-f942-11e3-9249-d2358968e7e7.png)
![capture decran 2014-06-21 a 14 15 06](https://cloud.githubusercontent.com/assets/6019000/3348806/1c10bf16-f942-11e3-9865-6e4b17d0e31b.png)
![capture decran 2014-06-21 a 14 47 50](https://cloud.githubusercontent.com/assets/6019000/3348810/4bb7c03e-f942-11e3-931e-d9f97bae65d4.png)
### Python

![capture decran 2014-06-21 a 14 35 49](https://cloud.githubusercontent.com/assets/6019000/3348814/7cca54a2-f942-11e3-8e34-2e31ce829eb6.png)
![capture decran 2014-06-21 a 14 34 21](https://cloud.githubusercontent.com/assets/6019000/3348815/864e6216-f942-11e3-8146-8ff9d49311cb.png)
