### PR TITLE
:lipstick: Correct "Foreground" annotation

### DIFF
--- a/stylesheets/variables.less
+++ b/stylesheets/variables.less
@@ -8,7 +8,7 @@
 @base0: #839496;
 @base1: #93a1a1;
 
-// Background
+// Foreground
 @base2: #eee8d5;
 @base3: #fdf6e3;
 


### PR DESCRIPTION
There were two "Background" sections in variables.less, and I think one was supposed to be "Foreground".
