### PR TITLE
Fix ruby syntax.

### DIFF
--- a/stylesheets/ruby.less
+++ b/stylesheets/ruby.less
@@ -73,4 +73,7 @@
   .support.function {
     color: @syntax-text-color;
   }
+  .support.function.kernel {
+    color: @green;
+  }
 }


### PR DESCRIPTION
I have updated the ruby.less file, and updated some classes as noted in #28.

The `class` defining keyword and the `def` keyword should be gray to match [solarized repo](https://github.com/altercation/ethanschoonover.com/blob/master/projects/solarized/README.md), but are currently green. I wasn't able to change them beause of the `end` keyword, I wasn't able to change `end` of closing `class` and `def` because my styles were applying to all `end` keywords and that's not solarized dark in ruby, I'm not sure if I was doing something wrong.
Photos are before and after my changes.
Before:
![screen shot 2014-12-10 at 7 07 39 pm](https://cloud.githubusercontent.com/assets/1993929/5387414/d742d672-809f-11e4-857b-f6ecb7886835.png)
After:
![screen shot 2014-12-10 at 7 07 08 pm](https://cloud.githubusercontent.com/assets/1993929/5387415/d7707906-809f-11e4-975c-4833973c0487.png)
