### PR TITLE
:bug: Remove `.punctuation.parameters` styling

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -148,12 +148,6 @@
   color: @red;
 }
 
-.punctuation {
-  &.parameters {
-    color: @green;
-  }
-}
-
 .property-name {
   color: @green;
 }


### PR DESCRIPTION
Fixes atom/solarized-dark-syntax#27, unintended coloring of opening parentheses
after `for` and `if` in C syntax, perhaps others.
