### PR TITLE
Match javascript syntax to solarized dark syntax

### DIFF
--- a/index.less
+++ b/index.less
@@ -2,14 +2,15 @@
 @import "syntax-variables";
 
 @import "base";
-@import "markdown";
-@import "css";
-@import "ruby";
-@import "python";
 @import "c";
-@import "php";
-@import "terminal";
+@import "css";
 @import "git-diff";
-@import "wrap-guide";
-@import "scala";
+@import "javascript";
 @import "linter";
+@import "markdown";
+@import "php";
+@import "python";
+@import "ruby";
+@import "scala";
+@import "terminal";
+@import "wrap-guide";

--- a/styles/javascript.less
+++ b/styles/javascript.less
@@ -1,7 +1,73 @@
 .source.js {
-  .punctuation {
-    &.parameters {
-      color: @green;  
-    }
+  .constant {
+    color: @green;
+  }
+
+  .comma {
+    color: @syntax-text-color;
+  }
+
+  .support.class {
+    color: @green;
+  }
+
+  .entity.name.type {
+    color: @yellow;
+  }
+  .entity.name {
+    color: @syntax-text-color;
+  }
+
+  .meta.brace {
+    color: @syntax-text-color;
+  }
+
+  .keyword {
+    color: @syntax-text-color;
+  }
+  .keyword.operator.new {
+    color: @green;
+  }
+  .keyword.control {
+    color: @green;
+  }
+  .keyword.control.regexp {
+    color: @cyan;
+  }
+
+  .variable {
+    color: @blue;
+  }
+  .variable.parameter {
+    color: @syntax-text-color;
+  }
+
+  .regexp {
+    color: @cyan;
+  }
+
+  .support.function {
+    color: @syntax-text-color;
+  }
+  .support.constant {
+    color: @syntax-text-color;
+  }
+
+  .constant.numeric {
+    color: @syntax-text-color;
+  }
+
+  .punctuation.terminator.statement {
+    color: @syntax-text-color;
+  }
+
+  .meta.delimiter.method.period {
+    color: @syntax-text-color;
+  }
+  .meta.brace.square {
+    color: @blue;
+  }
+  .meta.brace.curly {
+    color: @blue;
   }
 }


### PR DESCRIPTION
Before:
![screen shot 2015-02-03 at 4 16 04 pm](https://cloud.githubusercontent.com/assets/1993929/6030936/b699a6d4-abc0-11e4-9e69-dff0bab1d35f.png)

After:
![screen shot 2015-02-03 at 4 15 29 pm](https://cloud.githubusercontent.com/assets/1993929/6030935/b68176f4-abc0-11e4-8bb6-b274b9852a72.png)

For reference, the ideal .js file: http://ethanschoonover.com/solarized/img/screen-javascript-dark.png