### PR TITLE
add coffeescript syntax

### DIFF
--- a/index.less
+++ b/index.less
@@ -4,6 +4,7 @@
 @import "base";
 @import "c";
 @import "css";
+@import "coffee";
 @import "git-diff";
 @import "javascript";
 @import "linter";

--- a/styles/coffee.less
+++ b/styles/coffee.less
@@ -1,0 +1,34 @@
+.source.coffee {
+  .support.class {
+    color: @green;
+  }
+
+  .variable {
+    color: @blue;
+  }
+  .variable.parameter.function {
+    color: @syntax-text-color;
+  }
+  .variable.other.readwrite {
+    color: @green;
+  }
+
+  .storage.type.function {
+    color: @green;
+  }
+
+  .entity.name {
+    color: @syntax-text-color;
+  }
+
+  .meta.brace.round {
+    color: @syntax-text-color;
+  }
+  .meta.delimiter {
+    color: @syntax-text-color;
+  }
+
+  .punctuation.terminator {
+    color: @syntax-text-color;
+  }
+}


### PR DESCRIPTION
Since there's no official solarized dark syntax, I used textmate coffeescript as a base.

before:
![screen shot 2015-02-10 at 5 23 19 pm](https://cloud.githubusercontent.com/assets/1993929/6138802/ee47a962-b149-11e4-9e54-1fc1327017ea.png)

after:
![screen shot 2015-02-10 at 5 23 01 pm](https://cloud.githubusercontent.com/assets/1993929/6138803/ee49ddd6-b149-11e4-911a-b1f63ea10ba8.png)
