### PR TITLE
Revert adding type variables

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -63,18 +63,18 @@ atom-text-editor, :host {
     color: @orange;
   }
   &.name.tag {
-    color: @syntax-color-tag;
+    color: @blue;
   }
   &.constant {
     color: @red;
   }
   &.attribute-name {
-    color: @syntax-color-attribute;
+    color: @syntax-comment-color;
   }
 }
 
 .keyword {
-  color: @syntax-color-keyword;
+  color: @green;
 
   &.other {
     &.special-method {
@@ -96,7 +96,7 @@ atom-text-editor, :host {
 }
 
 .constant {
-  color: @syntax-color-constant;
+  color: @yellow;
 
   &.numeric,
   &.boolean,
@@ -135,7 +135,7 @@ atom-text-editor, :host {
 }
 
 .method .name {
-  color: @syntax-color-method;
+  color: @blue;
 }
 
 .operator.assignment {
@@ -147,7 +147,7 @@ atom-text-editor, :host {
 }
 
 .property-name {
-  color: @syntax-color-property;
+  color: @green;
 }
 
 .property-value {
@@ -178,7 +178,7 @@ atom-text-editor, :host {
 }
 
 .variable {
-  color: @syntax-color-variable;
+  color: @cyan;
 
   &.instance {
     color: @blue;
@@ -197,7 +197,7 @@ atom-text-editor, :host {
   color: @orange;
 
   &.class {
-    color: @syntax-color-class;
+    color: @red;
   }
 }
 

--- a/styles/c.less
+++ b/styles/c.less
@@ -3,7 +3,7 @@
     color: @red;
   }
   .keyword.control.import {
-    color: @syntax-color-import;
+    color: @red;
   }
   .punctuation.string {
     color: @cyan;

--- a/styles/css.less
+++ b/styles/css.less
@@ -32,7 +32,7 @@
     color: @yellow;
   }
   .property-value {
-    color: @syntax-color-value;
+    color: @cyan;
   }
   .unit {
     color: @cyan;
@@ -41,7 +41,7 @@
     color: @blue;
   }
   .rgb-value {
-    color: @syntax-color-value;
+    color: @cyan;
   }
   .id {
     color: @blue;


### PR DESCRIPTION
Sorry, I changed my mind about #38. This PR will revert the changes except for the type variables in `syntax-variables.less`. Compare with https://github.com/atom/solarized-dark-syntax/commit/3fb7be5deca2ea90d041e3eb09165d7707e82262

The reason is that by mixing those type variables with the color variables, it makes it harder to see the relationships and you always have to reference `syntax-variables.less`.  Also, should make it easier for other theme authors to just add the list without touching the rest.

ps. this is not that urgent since the changes are just under the hood and won't be noticed by users.