### PR TITLE
add jsx highlighting

### DIFF
--- a/styles/javascript.less
+++ b/styles/javascript.less
@@ -72,16 +72,7 @@
   }
 }
 .source.js.jsx {
-  .tag.open {
+  .entity.name.tag {
     color: @blue;
-    .entity.name.tag {
-      color: @blue;
-    }
-  }
-  .tag.closed {
-    color: @magenta;
-    .entity.name.tag {
-      color: @magenta;
-    }
   }
 }

--- a/styles/javascript.less
+++ b/styles/javascript.less
@@ -71,3 +71,17 @@
     color: @blue;
   }
 }
+.source.js.jsx {
+  .tag.open {
+    color: @blue;
+    .entity.name.tag {
+      color: @blue;
+    }
+  }
+  .tag.closed {
+    color: @magenta;
+    .entity.name.tag {
+      color: @magenta;
+    }
+  }
+}


### PR DESCRIPTION
After using react for a while at work I wanted to do some more specific highlighting for jsx tags.

Before:
![](https://photos-1.dropbox.com/t/2/AADmwtT1s0PojU9vLf6leBOSJvIQTX9K-89wErdE1h5-aQ/12/111976830/png/32x32/1/1432605600/0/2/Screenshot%202015-05-25%2017.27.31.png/CP7CsjUgASACIAMgBCAFIAYoAQ/K8atAD0Yl3HEL55RkWZxu-XliCeWM4BDMoRbyKndKPA?size_mode=5)
After:
![](https://photos-5.dropbox.com/t/2/AABZ4_1lmng9WPtCdHYjt4Q8KV9UiJm-5SF6P73OD6ncUA/12/111976830/png/32x32/1/1432605600/0/2/Screenshot%202015-05-25%2017.28.02.png/CP7CsjUgASACIAMgBCAFIAYoAQ/uZryS8Vho7ikNcEmUD2LGEfYQ87QTJ4Qqzx5NUzzk0U?size_mode=5)

I think the blue color for opening and magenta color for closing is a nice addition. If not tags could also just be blue. Let me know what you think!