### PR TITLE
Fix .embedded in Scala from being cut off

### DIFF
--- a/styles/scala.less
+++ b/styles/scala.less
@@ -68,10 +68,9 @@
   }
 
   .embedded {
-    color: @syntax-emphasized-color;
+    color: darken(@syntax-emphasized-color, 15%);
 
     // so we dont confused it with normal expressions
-    opacity: 0.8;
     font-style: italic;
     .margin, .delimiters {
       font-style: normal;


### PR DESCRIPTION
This PR removes the `opacity` from `.embedded` in Scala and darkens the `color` instead. This fixes italic text from being cut off. Note the `$f` in the screenshot:

Before 

![screen shot 2015-11-11 at 2 42 00 pm](https://cloud.githubusercontent.com/assets/378023/11084789/c5aa01f6-8882-11e5-8bba-bce23fb6d959.png)

After

![screen shot 2015-11-11 at 2 38 21 pm](https://cloud.githubusercontent.com/assets/378023/11084790/c9d98c60-8882-11e5-9746-a5e75e02fc81.png)

Fixes #44