### PR TITLE
Go support

### DIFF
--- a/index.less
+++ b/index.less
@@ -6,6 +6,7 @@
 @import "css";
 @import "coffee";
 @import "git-diff";
+@import "go";
 @import "javascript";
 @import "linter";
 @import "markdown";

--- a/styles/go.less
+++ b/styles/go.less
@@ -1,0 +1,39 @@
+.source.go {
+
+  .entity.name {
+    color: @base0;
+    &.function {
+      color: @blue;
+    }
+  }
+
+  .support {
+    color: @blue;
+  }
+
+  .storage {
+    color: @green;
+  }
+
+  .variable {
+    color: @blue;
+  }
+
+  .constant.numeric {
+    color: @magenta;
+  }
+
+  .operator {
+    color: @base0;
+    &.assignment {
+      color: @green;
+    }
+  }
+
+  .punctuation.terminator,
+  .delimiter,
+  .round {
+    color: @base0;
+  }
+
+}


### PR DESCRIPTION
This PR adds support for Go and makes it closer to TextMate and Sublime ports. Closes #47

Before

![screen shot 2015-11-11 at 9 09 47 pm](https://cloud.githubusercontent.com/assets/378023/11090822/91b632b2-88b8-11e5-9ffe-39c714840052.png)

After

![screen shot 2015-11-11 at 9 09 05 pm](https://cloud.githubusercontent.com/assets/378023/11090824/97ebd452-88b8-11e5-8b1d-d1056fe2aed0.png)