### PR TITLE
Match other Solarized ports

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -53,8 +53,9 @@ atom-text-editor, :host {
 }
 
 .string {
-  color: @cyan;
-
+  &.quoted {
+    color: @cyan;
+  }
   &.regexp {
     color: @red;
   }
@@ -94,13 +95,16 @@ atom-text-editor, :host {
     }
   }
   &.other.attribute-name {
-    color: @base1;
+    color: @base00;
   }
 }
 
 .support {
   &.function {
     color: @blue;
+    &.builtin {
+      color: @green;
+    }
   }
   &.type,
   &.class {
@@ -123,7 +127,7 @@ atom-text-editor, :host {
 
 .invalid {
   &.deprecated {
-    color: @orange;
+    color: @yellow;
     text-decoration: underline;
   }
   &.illegal {

--- a/styles/base.less
+++ b/styles/base.less
@@ -52,155 +52,86 @@ atom-text-editor, :host {
   font-style: italic;
 }
 
-.entity {
-  color: @syntax-text-color;
-
-  .punctuation {
-    color: @red;
-  }
-
-  &.name {
-    color: @orange;
-  }
-  &.name.tag {
-    color: @blue;
-  }
-  &.constant {
-    color: @red;
-  }
-  &.attribute-name {
-    color: @syntax-comment-color;
-  }
-}
-
-.keyword {
-  color: @green;
-
-  &.other {
-    &.special-method {
-      color: @orange;
-    }
-  }
-}
-
-.storage.type {
-  color: @blue;
-}
-
-.storage.class.type {
-  color: @magenta;
-}
-
-.storage.modifier {
-  color: @blue;
-}
-
-.constant {
-  color: @yellow;
-
-  &.numeric,
-  &.boolean,
-  &.symbol, &.symbol .punctuation {
-    color: @cyan;
-  }
-
-  &.symbol.hashkey {
-    color: @red;
-
-    .punctuation {
-      color: @red;
-    }
-  }
-}
-
-.delimiter, .brace {
-  color: @blue;
-}
-
-.delimiter, .round {
-  color: @green;
-}
-
-.delimiter.period {
-  color: @green;
-}
-
-.invalid.deprecated {
-  text-decoration: underline;
-  color: @red;
-}
-
-.invalid.illegal {
-  color: @red;
-}
-
-.method .name {
-  color: @blue;
-}
-
-.operator.assignment {
-  color: @syntax-emphasized-color;
-}
-
-.parameter {
-  color: @red;
-}
-
-.property-name {
-  color: @green;
-}
-
-.property-value {
-  .unit {
-    color: @syntax-text-color;
-  }
-}
-
 .string {
   color: @cyan;
 
-  .constant.character.escape {
-    color: @red;
-    font-weight: bold;
-  }
-
-  .punctuation.string {
-    color: @cyan;
-  }
-
   &.regexp {
-    color: @cyan;
+    color: @red;
+  }
+}
 
-    .string.regexp.arbitrary-repetition {
-      color: @cyan;
-    }
+.constant {
+  &.numeric {
+    color: @magenta;
+  }
+  &.language {
+    color: @yellow;
+  }
+  &.character,
+  &.other {
+    color: @orange;
   }
 }
 
 .variable {
-  color: @cyan;
+  color: @blue;
+}
 
-  &.instance {
-    color: @blue;
+.keyword {
+  color: @green;
+}
+
+.storage {
+  color: @green;
+}
+
+.entity {
+  &.name {
+    &.class,
+    &.type,
+    &.function {
+      color: @blue;
+    }
   }
-
-  &.constant {
-    color: @syntax-comment-color;
-  }
-
-  &.parameter {
-    color: @red;
+  &.other.attribute-name {
+    color: @base1;
   }
 }
 
 .support {
-  color: @orange;
-
+  &.function {
+    color: @blue;
+  }
+  &.type,
   &.class {
-    color: @red;
+    color: @green;
   }
 }
 
-.terminator {
-  color: @green;
+.tag {
+  &.entity.name {
+    color: @blue;
+  }
+  &.punctuation.definition {
+    &.html,
+    &.begin,
+    &.end {
+      color: @base01;
+    }
+  }
+}
+
+.invalid {
+  &.deprecated {
+    color: @orange;
+    text-decoration: underline;
+  }
+  &.illegal {
+    color: @red;
+    text-decoration: underline;
+  }
+}
+
+.none {
+  color: @syntax-text-color;
 }

--- a/styles/c.less
+++ b/styles/c.less
@@ -3,13 +3,16 @@
     color: @red;
   }
   .keyword.control.import {
-    color: @red;
+    color: @orange;
+  }
+  .punctuation.definition.keyword {
+    color: @orange;
   }
   .punctuation.string {
     color: @cyan;
   }
   .constant {
-    color: @red;
+    color: @orange;
 
     &.numeric, &.language.c {
       color: @cyan;

--- a/styles/css.less
+++ b/styles/css.less
@@ -1,59 +1,63 @@
 .source.css {
+
+  .punctuation {
+    &.separator,
+    &.terminator {
+      color: @syntax-text-color;
+    }
+    &.property-list.begin,
+    &.property-list.end {
+      color: @red;
+    }
+    &.section.function {
+      color: @cyan;
+    }
+  }
+
   .entity.name {
     color: @green;
   }
-  .punctuation.section {
+  .attribute-name.class,
+  .id {
     color: @blue;
   }
-  .punctuation.separator {
-    color: @syntax-text-color;
+  .pseudo-element,
+  .pseudo-class {
+    color: @orange;
   }
-  .punctuation.terminator {
-    color: @syntax-text-color;
-  }
-  .punctuation.definition {
-    &.entity {
-      color: @blue;
-    }
-    &.constant {
-      color: @syntax-text-color;
-    }
-  }
-  .brace {
-    color: @blue;
-  }
-  .variable {
-    color: @blue;
-  }
-  .attribute-name.class {
-    color: @blue;
-  }
-  .property-name {
-    color: @yellow;
-  }
+
   .property-value {
     color: @cyan;
   }
-  .unit {
+  .constant.numeric {
     color: @cyan;
-  }
-  .support.function {
-    color: @blue;
+    .unit {
+      color: @cyan;
+    }
   }
   .rgb-value {
     color: @cyan;
   }
-  .id {
-    color: @blue;
-  }
-  .pseudo-element {
-    color: @orange;
-  }
-  .pseudo-class {
-    color: @orange;
-
-    &.attribute-name {
-      color: @orange;
+  .support.constant {
+    color: @cyan;
+    &.media {
+      color: @red;
     }
+  }
+
+  .keyword.important {
+    color: @red;
+  }
+
+}
+
+
+// Less/Sass should have their own files,
+// but for just a single override, here should be fine too
+
+.source.less,
+.source.scss {
+  .keyword.unit {
+    color: @cyan;
   }
 }

--- a/styles/go.less
+++ b/styles/go.less
@@ -1,39 +1,10 @@
 .source.go {
 
-  .entity.name {
-    color: @base0;
-    &.function {
-      color: @blue;
-    }
-  }
-
-  .support {
-    color: @blue;
-  }
-
-  .storage {
-    color: @green;
-  }
-
-  .variable {
-    color: @blue;
-  }
-
-  .constant.numeric {
-    color: @magenta;
-  }
-
   .operator {
     color: @base0;
     &.assignment {
       color: @green;
     }
-  }
-
-  .punctuation.terminator,
-  .delimiter,
-  .round {
-    color: @base0;
   }
 
 }

--- a/styles/markdown.less
+++ b/styles/markdown.less
@@ -3,11 +3,23 @@
     color: @violet;
   }
 
+  .list {
+    &.ordered {
+      color: @green;
+    }
+    &.unordered {
+      color: @yellow;
+    }
+  }
+
   .raw {
     font-style: italic;
   }
 
   &.support {
-    color: @red;
+    color:@syntax-comment-color;
+    &.quote {
+      color: @violet;
+    }
   }
 }

--- a/styles/markup.less
+++ b/styles/markup.less
@@ -1,17 +1,30 @@
 .markup {
-  &.italic {
-    font-style: italic;
-  }
 
   &.bold {
     font-weight: bold;
   }
+  &.italic {
+    font-style: italic;
+  }
 
   &.heading {
-    color: @orange;
+    color: @blue;
   }
 
   &.link {
     color: @cyan;
   }
+
+  &.deleted {
+    color: @red;
+  }
+
+  &.changed {
+    color: @yellow;
+  }
+
+  &.inserted {
+    color: @cyan;
+  }
+
 }

--- a/styles/php.less
+++ b/styles/php.less
@@ -5,7 +5,7 @@
         color: @yellow;
       }
       &.function {
-        color: @red;
+        color: @orange;
       }
     }
     &.modifier {
@@ -42,9 +42,6 @@
     &.variable {
       color: @green;
     }
-  }
-  .punctuation.section.scope {
-    color: @red;
   }
   .support.function {
     &.construct {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -34,13 +34,13 @@
 @syntax-color-removed: @red;
 
 // For language entity colors
-@syntax-color-variable: @cyan;
+@syntax-color-variable: @blue;
 @syntax-color-constant: @yellow;
-@syntax-color-property: @green;
+@syntax-color-property: @yellow;
 @syntax-color-value: @cyan;
 @syntax-color-function: @blue;
 @syntax-color-method: @blue;
-@syntax-color-class: @red;
+@syntax-color-class: @blue;
 @syntax-color-keyword: @green;
 @syntax-color-tag: @blue;
 @syntax-color-attribute: @syntax-comment-color;


### PR DESCRIPTION
This PR changes the `base.less` colors.

It will most likely "break" stuff in a few places, but should make it match more other Solarized ports (Sublime, TextMate).

- [x] `base.less`
- [x] autocomplete variables
- [x] update all languages

Closes #55