### PR TITLE
Fix missing keywords in ruby

### DIFF
--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -25,6 +25,9 @@
   .variable.constant {
     color: @yellow;
   }
+  .constant.boolean {
+    color: @cyan;
+  }
   .instance {
     .punctuation.definition {
       color: @blue;
@@ -83,8 +86,20 @@
   .variable.block {
     color: @blue;
   }
+  .variable.self {
+    color: @cyan;
+  }
   .punctuation.separator {
     color: @syntax-text-color;
+  }
+  .numeric {
+    color: @cyan;
+  }
+  .punctuation.section.regexp {
+    color: @red;
+  }
+  .string.interpolated {
+    color: @cyan;
   }
   .string.interpolated {
     .embedded.line.ruby {

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -56,6 +56,9 @@
   .keyword.control {
     color: @green;
   }
+  .keyword.operator {
+    color: @syntax-text-color;
+  }
   .special-method {
     color: @blue;
   }


### PR DESCRIPTION
Update colors that aren't as in the official solarized.

Official colors:
![screen shot 2016-03-28 at 10 54 06 am](https://cloud.githubusercontent.com/assets/1993929/14083748/8b831878-f4d4-11e5-97b5-9a26b066a7b7.png)

Before PR:
![screen shot 2016-03-28 at 11 02 44 am](https://cloud.githubusercontent.com/assets/1993929/14083772/a50900e6-f4d4-11e5-8aba-9b0464f2d704.png)

After PR:
![screen shot 2016-03-28 at 11 00 29 am](https://cloud.githubusercontent.com/assets/1993929/14083800/be00d006-f4d4-11e5-9d14-08c43db2398a.png)




