### PR TITLE
Fix embedded JS closing script tags

### DIFF
--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -78,6 +78,9 @@
       }
     }
   }
+  &.embedded .entity.name.tag {
+    color: @blue;
+  }
 }
 .source.js.jsx {
   .entity.name.tag {


### PR DESCRIPTION
This fixes the highlighting of closing script tags when embedded in HTML.

![screen shot 2016-09-20 at 2 43 46 pm](https://cloud.githubusercontent.com/assets/378023/18658793/d21de370-7f40-11e6-9c50-d844db47744d.png)

Fixes #69