### PR TITLE
Don’t highlight links in comments

### DIFF
--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -2,6 +2,10 @@
 .comment {
   color: @syntax-comment-color;
   font-style: italic;
+
+  .markup.link {
+    color: @syntax-comment-color;
+  }
 }
 
 .string {


### PR DESCRIPTION
Fixes #71