### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,5 +1,4 @@
-atom-text-editor,
-:host {
+atom-text-editor {
   color: @syntax-text-color;
   background-color: @syntax-background-color;
 

--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -1,95 +1,95 @@
 
-.comment {
+.syntax--comment {
   color: @syntax-comment-color;
   font-style: italic;
 
-  .markup.link {
+  .syntax--markup.syntax--link {
     color: @syntax-comment-color;
   }
 }
 
-.string {
+.syntax--string {
   color: @cyan;
-  &.regexp {
+  &.syntax--regexp {
     color: @red;
   }
 }
 
-.constant {
-  &.numeric {
+.syntax--constant {
+  &.syntax--numeric {
     color: @magenta;
   }
-  &.language {
+  &.syntax--language {
     color: @yellow;
   }
-  &.character,
-  &.other {
+  &.syntax--character,
+  &.syntax--other {
     color: @orange;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @blue;
 }
 
-.keyword {
+.syntax--keyword {
   color: @green;
 }
 
-.storage {
+.syntax--storage {
   color: @green;
 }
 
-.entity {
-  &.name {
-    &.class,
-    &.type,
-    &.function {
+.syntax--entity {
+  &.syntax--name {
+    &.syntax--class,
+    &.syntax--type,
+    &.syntax--function {
       color: @blue;
     }
   }
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @syntax-subtle-color;
   }
 }
 
-.support {
-  &.function {
+.syntax--support {
+  &.syntax--function {
     color: @blue;
-    &.builtin {
+    &.syntax--builtin {
       color: @green;
     }
   }
-  &.type,
-  &.class {
+  &.syntax--type,
+  &.syntax--class {
     color: @green;
   }
 }
 
-.tag {
-  &.entity.name {
+.syntax--tag {
+  &.syntax--entity.syntax--name {
     color: @blue;
   }
-  &.punctuation.definition {
-    &.html,
-    &.begin,
-    &.end {
+  &.syntax--punctuation.syntax--definition {
+    &.syntax--html,
+    &.syntax--begin,
+    &.syntax--end {
       color: @syntax-comment-color;
     }
   }
 }
 
-.invalid {
-  &.deprecated {
+.syntax--invalid {
+  &.syntax--deprecated {
     color: @yellow;
     text-decoration: underline;
   }
-  &.illegal {
+  &.syntax--illegal {
     color: @red;
     text-decoration: underline;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }

--- a/styles/languages/c.less
+++ b/styles/languages/c.less
@@ -1,43 +1,43 @@
-.source.c,
-.source.cpp {
-  .meta.preprocessor {
+.syntax--source.syntax--c,
+.syntax--source.syntax--cpp {
+  .syntax--meta.syntax--preprocessor {
     color: @red;
   }
-  .keyword.control.directive {
+  .syntax--keyword.syntax--control.syntax--directive {
     color: @orange;
   }
-  .punctuation.string {
+  .syntax--punctuation.syntax--string {
     color: @cyan;
   }
-  .constant {
+  .syntax--constant {
     color: @orange;
 
-    &.numeric, &.language.c {
+    &.syntax--numeric, &.syntax--language.syntax--c {
       color: @cyan;
     }
   }
-  .storage {
+  .syntax--storage {
     color: @yellow;
   }
-  .entity {
+  .syntax--entity {
     color: @syntax-text-color;
 
-    &.name.function.preprocessor {
+    &.syntax--name.syntax--function.syntax--preprocessor {
       color: @red;
     }
   }
-  .support.type {
+  .syntax--support.syntax--type {
     color: @yellow;
 
-    &.posix-reserved {
+    &.syntax--posix-reserved {
       color: @syntax-text-color;
     }
   }
-  .variable {
-    &.other.dot-access {
+  .syntax--variable {
+    &.syntax--other.syntax--dot-access {
       color: @syntax-text-color;
     }
-    &.parameter.preprocessor {
+    &.syntax--parameter.syntax--preprocessor {
       color: @red;
     }
   }

--- a/styles/languages/coffee.less
+++ b/styles/languages/coffee.less
@@ -1,55 +1,55 @@
-.source.coffee {
-  .support.class {
+.syntax--source.syntax--coffee {
+  .syntax--support.syntax--class {
     color: @green;
   }
 
-  .variable,
-  .entity.name.function,
-  .entity.name.class {
+  .syntax--variable,
+  .syntax--entity.syntax--name.syntax--function,
+  .syntax--entity.syntax--name.syntax--class {
     color: @blue;
   }
-  .variable.parameter.function {
+  .syntax--variable.syntax--parameter.syntax--function {
     color: @syntax-text-color;
   }
-  .variable.other.readwrite {
+  .syntax--variable.syntax--other.syntax--readwrite {
     color: @green;
   }
 
-  .storage.type.function {
+  .syntax--storage.syntax--type.syntax--function {
     color: @green;
   }
 
-  .entity.name {
+  .syntax--entity.syntax--name {
     color: @syntax-text-color;
   }
 
-  .meta.brace {
-    &.round,
-    &.square {
+  .syntax--meta.syntax--brace {
+    &.syntax--round,
+    &.syntax--square {
       color: @syntax-text-color;
     }
   }
-  .meta.delimiter {
+  .syntax--meta.syntax--delimiter {
     color: @syntax-text-color;
   }
 
-  .storage.type.class {
+  .syntax--storage.syntax--type.syntax--class {
     color: @green;
   }
 
-  .punctuation.terminator {
+  .syntax--punctuation.syntax--terminator {
     color: @syntax-text-color;
   }
 
-  .punctuation.section.embedded {
+  .syntax--punctuation.syntax--section.syntax--embedded {
     color: @red;
   }
 
-  .constant.numeric {
+  .syntax--constant.syntax--numeric {
     color: @magenta;
   }
 
-  .constant.language.boolean {
+  .syntax--constant.syntax--language.syntax--boolean {
     color: @yellow;
   }
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,51 +1,51 @@
-.source.css {
+.syntax--source.syntax--css {
 
-  .punctuation {
-    &.separator,
-    &.terminator {
+  .syntax--punctuation {
+    &.syntax--separator,
+    &.syntax--terminator {
       color: @syntax-text-color;
     }
-    &.property-list.begin,
-    &.property-list.end {
+    &.syntax--property-list.syntax--begin,
+    &.syntax--property-list.syntax--end {
       color: @red;
     }
-    &.section.function {
+    &.syntax--section.syntax--function {
       color: @cyan;
     }
   }
 
-  .entity.name {
+  .syntax--entity.syntax--name {
     color: @green;
   }
-  .attribute-name.class,
-  .id {
+  .syntax--attribute-name.syntax--class,
+  .syntax--id {
     color: @blue;
   }
-  .pseudo-element,
-  .pseudo-class {
+  .syntax--pseudo-element,
+  .syntax--pseudo-class {
     color: @orange;
   }
 
-  .property-value {
+  .syntax--property-value {
     color: @cyan;
   }
-  .constant.numeric {
+  .syntax--constant.syntax--numeric {
     color: @cyan;
-    .unit {
+    .syntax--unit {
       color: @cyan;
     }
   }
-  .rgb-value {
+  .syntax--rgb-value {
     color: @cyan;
   }
-  .support.constant {
+  .syntax--support.syntax--constant {
     color: @cyan;
-    &.media {
+    &.syntax--media {
       color: @red;
     }
   }
 
-  .keyword.important {
+  .syntax--keyword.syntax--important {
     color: @red;
   }
 
@@ -55,9 +55,9 @@
 // Less/Sass should have their own files,
 // but for just a single override, here should be fine too
 
-.source.less,
-.source.scss {
-  .keyword.unit {
+.syntax--source.syntax--less,
+.syntax--source.syntax--scss {
+  .syntax--keyword.syntax--unit {
     color: @cyan;
   }
 }

--- a/styles/languages/go.less
+++ b/styles/languages/go.less
@@ -1,8 +1,8 @@
-.source.go {
+.syntax--source.syntax--go {
 
-  .operator {
+  .syntax--operator {
     color: @syntax-text-color;
-    &.assignment {
+    &.syntax--assignment {
       color: @green;
     }
   }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,47 +1,47 @@
-.source.java {
-  .keyword.operator{
+.syntax--source.syntax--java {
+  .syntax--keyword.syntax--operator{
     color:@green;
   }
-  .keyword.import{
+  .syntax--keyword.syntax--import{
     color: @orange;
   }
-  .storage.modifier.import{
+  .syntax--storage.syntax--modifier.syntax--import{
     color: @syntax-comment-color;
   }
-  .meta.class{
-    .storage.modifier{
+  .syntax--meta.syntax--class{
+    .syntax--storage.syntax--modifier{
       color: @yellow;
     }
-    .meta.class.identifier{
-      .entity.name.type.class{
+    .syntax--meta.syntax--class.syntax--identifier{
+      .syntax--entity.syntax--name.syntax--type.syntax--class{
         color: @blue;
       }
     }
   }
-  .storage.type.primitive.array{
+  .syntax--storage.syntax--type.syntax--primitive.syntax--array{
     color:@green;
   }
-  .constant.numeric{
+  .syntax--constant.syntax--numeric{
     color:@magenta;
   }
-  .constant.other{
+  .syntax--constant.syntax--other{
     color:@orange;
   }
-  .storage.type{
+  .syntax--storage.syntax--type{
     color:@green;
   }
-  .meta.method-call{
+  .syntax--meta.syntax--method-call{
     //@ibocon: method parameter's color
     color:@red;
     //@ibocon: method and variable use different hightlight
-    .meta.method{
+    .syntax--meta.syntax--method{
       color:@violet;
     }
-    .punctuation.definition.seperator.parameter{
+    .syntax--punctuation.syntax--definition.syntax--seperator.syntax--parameter{
       color:@green;
     }
   }
-  .punctuation.definition.method-parameters{
+  .syntax--punctuation.syntax--definition.syntax--method-parameters{
     color: @syntax-emphasized-color;
   }
 }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,89 +1,89 @@
-.source.js {
-  .constant {
+.syntax--source.syntax--js {
+  .syntax--constant {
     color: @green;
   }
 
-  .comma {
+  .syntax--comma {
     color: @syntax-text-color;
   }
 
-  .support.class {
+  .syntax--support.syntax--class {
     color: @green;
   }
 
-  .entity.name.type {
+  .syntax--entity.syntax--name.syntax--type {
     color: @yellow;
   }
-  .entity.name {
+  .syntax--entity.syntax--name {
     color: @syntax-text-color;
   }
 
-  .meta.brace {
+  .syntax--meta.syntax--brace {
     color: @syntax-text-color;
   }
 
-  .keyword {
+  .syntax--keyword {
     color: @syntax-text-color;
   }
-  .keyword.operator.new {
+  .syntax--keyword.syntax--operator.syntax--new {
     color: @green;
   }
-  .keyword.control {
+  .syntax--keyword.syntax--control {
     color: @green;
   }
-  .keyword.control.regexp {
+  .syntax--keyword.syntax--control.syntax--regexp {
     color: @cyan;
   }
 
-  .variable {
+  .syntax--variable {
     color: @blue;
   }
-  .variable.parameter {
+  .syntax--variable.syntax--parameter {
     color: @syntax-text-color;
   }
 
-  .regexp {
+  .syntax--regexp {
     color: @cyan;
   }
 
-  .support.function {
+  .syntax--support.syntax--function {
     color: @violet;
   }
-  .support.constant {
+  .syntax--support.syntax--constant {
     color: @syntax-text-color;
   }
 
-  .constant.numeric {
+  .syntax--constant.syntax--numeric {
     color: @syntax-text-color;
   }
 
-  .punctuation.terminator.statement {
+  .syntax--punctuation.syntax--terminator.syntax--statement {
     color: @syntax-text-color;
   }
 
-  .meta.delimiter.method.period {
+  .syntax--meta.syntax--delimiter.syntax--method.syntax--period {
     color: @syntax-text-color;
   }
-  .meta.brace.square {
+  .syntax--meta.syntax--brace.syntax--square {
     color: @blue;
   }
-  .meta.brace.curly {
+  .syntax--meta.syntax--brace.syntax--curly {
     color: @blue;
   }
-  .string.quoted.template {
-    .embedded.source {
+  .syntax--string.syntax--quoted.syntax--template {
+    .syntax--embedded.syntax--source {
       color: @syntax-text-color;
-      & > .embedded.punctuation {
+      & > .syntax--embedded.syntax--punctuation {
         color: @red;
       }
     }
   }
-  &.embedded .entity.name.tag {
+  &.syntax--embedded .syntax--entity.syntax--name.syntax--tag {
     color: @blue;
   }
 }
-.source.js.jsx {
-  .entity.name.tag {
+.syntax--source.syntax--js.syntax--jsx {
+  .syntax--entity.syntax--name.syntax--tag {
     color: @blue;
   }
 }

--- a/styles/languages/markdown.less
+++ b/styles/languages/markdown.less
@@ -1,24 +1,24 @@
-.gfm {
-  .link .entity {
+.syntax--gfm {
+  .syntax--link .syntax--entity {
     color: @violet;
   }
 
-  .list {
-    &.ordered {
+  .syntax--list {
+    &.syntax--ordered {
       color: @green;
     }
-    &.unordered {
+    &.syntax--unordered {
       color: @yellow;
     }
   }
 
-  .raw {
+  .syntax--raw {
     font-style: italic;
   }
 
-  &.support {
+  &.syntax--support {
     color:@syntax-comment-color;
-    &.quote {
+    &.syntax--quote {
       color: @violet;
     }
   }

--- a/styles/languages/markup.less
+++ b/styles/languages/markup.less
@@ -1,29 +1,29 @@
-.markup {
+.syntax--markup {
 
-  &.bold {
+  &.syntax--bold {
     font-weight: bold;
   }
-  &.italic {
+  &.syntax--italic {
     font-style: italic;
   }
 
-  &.heading {
+  &.syntax--heading {
     color: @blue;
   }
 
-  &.link {
+  &.syntax--link {
     color: @cyan;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @red;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @yellow;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @cyan;
   }
 

--- a/styles/languages/php.less
+++ b/styles/languages/php.less
@@ -1,66 +1,66 @@
-.source.php {
-  .storage {
-    &.type {
-      &.class {
+.syntax--source.syntax--php {
+  .syntax--storage {
+    &.syntax--type {
+      &.syntax--class {
         color: @yellow;
       }
-      &.function {
+      &.syntax--function {
         color: @orange;
       }
     }
-    &.modifier {
+    &.syntax--modifier {
       color: @yellow;
     }
   }
-  .entity {
-    &.name {
-      &.type.class {
+  .syntax--entity {
+    &.syntax--name {
+      &.syntax--type.syntax--class {
         color: @syntax-text-color;
       }
-      &.function {
+      &.syntax--function {
         color: @syntax-text-color;
       }
     }
-    &.other {
+    &.syntax--other {
       color: @syntax-text-color;
     }
   }
-  .variable {
+  .syntax--variable {
     color: @blue;
   }
-  .punctuation.definition {
+  .syntax--punctuation.syntax--definition {
     color: @syntax-text-color;
-    &.comment {
+    &.syntax--comment {
       color: @syntax-comment-color;
     }
-    &.array {
+    &.syntax--array {
       color: @red;
     }
-    &.string {
+    &.syntax--string {
       color: @syntax-text-color;
     }
-    &.variable {
+    &.syntax--variable {
       color: @green;
     }
   }
-  .support.function {
-    &.construct {
+  .syntax--support.syntax--function {
+    &.syntax--construct {
       color: @yellow;
     }
-    &.array {
+    &.syntax--array {
       color: @green;
     }
   }
-  .keyword {
-    &.operator {
-      &.class {
+  .syntax--keyword {
+    &.syntax--operator {
+      &.syntax--class {
         color: @yellow;
       }
-      &.assignment {
+      &.syntax--assignment {
         color: @green;
       }
     }
-    &.other {
+    &.syntax--other {
       color: @red;
     }
   }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,98 +1,98 @@
-.source.python {
-  .entity {
+.syntax--source.syntax--python {
+  .syntax--entity {
     color: @syntax-text-color;
 
-    &.name {
+    &.syntax--name {
       color: @blue;
     }
-    &.other {
+    &.syntax--other {
       color: @blue;
     }
   }
 
-  .function {
+  .syntax--function {
     color: @blue;
 
-    &.magic {
+    &.syntax--magic {
       color: @blue;
     }
   }
 
-  .punctuation.string {
+  .syntax--punctuation.syntax--string {
     color: @cyan;
   }
-  .keyword {
-    &.operator {
+  .syntax--keyword {
+    &.syntax--operator {
       color: @syntax-text-color;
-      &.quantifier {
+      &.syntax--quantifier {
         color: @cyan;
       }
-      &.logical {
+      &.syntax--logical {
         color: @green;
       }
     }
-    &.control.import {
+    &.syntax--control.syntax--import {
       color: @orange;
     }
-    &.other {
+    &.syntax--other {
       color: @green;
     }
   }
-  .constant {
-    &.language {
+  .syntax--constant {
+    &.syntax--language {
       color: @blue;
     }
-    &.character {
+    &.syntax--character {
       color: @cyan;
     }
-    &.other {
+    &.syntax--other {
       color: @red;
     }
   }
 
-  .entity.name.type.class {
+  .syntax--entity.syntax--name.syntax--type.syntax--class {
     color: @blue;
   }
-  .variable {
+  .syntax--variable {
     color: @syntax-text-color;
   }
-  .support {
-    &.function.builtin {
+  .syntax--support {
+    &.syntax--function.syntax--builtin {
       color: @blue;
     }
-    &.type {
-      &.exception.python {
+    &.syntax--type {
+      &.syntax--exception.syntax--python {
         color: @yellow;
       }
-      &.python {
+      &.syntax--python {
         color: @blue;
       }
     }
   }
-  .storage.type.string {
+  .syntax--storage.syntax--type.syntax--string {
     color: @cyan;
   }
 
-  .storage.type.class {
+  .syntax--storage.syntax--type.syntax--class {
     color: @green;
-    &.todo {
+    &.syntax--todo {
       color: @magenta;
     }
   }
 
-  .storage.type.function {
+  .syntax--storage.syntax--type.syntax--function {
     color: @green;
   }
 
-  .punctuation.definition.parameters {
+  .syntax--punctuation.syntax--definition.syntax--parameters {
     color: @syntax-text-color;
   }
 
-  .punctuation.section.function.begin {
+  .syntax--punctuation.syntax--section.syntax--function.syntax--begin {
     color: @syntax-text-color;
   }
 
-  .punctuation.separator.parameters {
+  .syntax--punctuation.syntax--separator.syntax--parameters {
     color: @syntax-text-color;
   }
 

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,129 +1,129 @@
-.source.ruby {
+.syntax--source.syntax--ruby {
 
-  .meta.embedded {
-    .punctuation.section {
+  .syntax--meta.syntax--embedded {
+    .syntax--punctuation.syntax--section {
       color: @red;
     }
   }
-  .punctuation.definition {
+  .syntax--punctuation.syntax--definition {
     color: @syntax-text-color;
-    &.string {
+    &.syntax--string {
       color: @red;
     }
   }
-  .punctuation.definition.comment {
+  .syntax--punctuation.syntax--definition.syntax--comment {
     color: @syntax-comment-color;
   }
-  .entity.inherited-class {
+  .syntax--entity.syntax--inherited-class {
     color: @yellow;
   }
-  .variable {
-    &.parameter {
+  .syntax--variable {
+    &.syntax--parameter {
       color: @syntax-text-color;
     }
   }
-  .variable.constant {
+  .syntax--variable.syntax--constant {
     color: @yellow;
   }
-  .constant.boolean {
+  .syntax--constant.syntax--boolean {
     color: @cyan;
   }
-  .instance {
-    .punctuation.definition {
+  .syntax--instance {
+    .syntax--punctuation.syntax--definition {
       color: @blue;
     }
   }
-  .class {
+  .syntax--class {
     color: @yellow;
-    &.control {
+    &.syntax--control {
       color: @syntax-text-color;
     }
   }
-  .module {
+  .syntax--module {
     color: @yellow;
   }
-  .require {
-    .keyword.other.special-method {
+  .syntax--require {
+    .syntax--keyword.syntax--other.syntax--special-method {
       color: @orange;
     }
   }
-  .keyword.other.special-method {
+  .syntax--keyword.syntax--other.syntax--special-method {
     color: @orange;
   }
-  .keyword.other {
+  .syntax--keyword.syntax--other {
     color: @green;
   }
-  .keyword.control {
+  .syntax--keyword.syntax--control {
     color: @green;
   }
-  .keyword.operator {
+  .syntax--keyword.syntax--operator {
     color: @syntax-text-color;
   }
-  .special-method {
+  .syntax--special-method {
     color: @blue;
   }
-  .symbol {
+  .syntax--symbol {
     color: @cyan;
-    .punctuation.definition {
+    .syntax--punctuation.syntax--definition {
       color: @cyan;
     }
   }
-  .hashkey {
+  .syntax--hashkey {
     color: @red;
-    .punctuation.definition {
+    .syntax--punctuation.syntax--definition {
       color: @red;
     }
   }
-  .string.regexp {
+  .syntax--string.syntax--regexp {
     color: @red;
   }
-  .todo {
+  .syntax--todo {
     color: @magenta;
   }
-  .variable.ruby.global {
+  .syntax--variable.syntax--ruby.syntax--global {
     color: @blue;
-    .punctuation {
+    .syntax--punctuation {
       color: @blue;
     }
   }
-  .variable.block {
+  .syntax--variable.syntax--block {
     color: @blue;
   }
-  .variable.self {
+  .syntax--variable.syntax--self {
     color: @cyan;
   }
-  .punctuation.separator {
+  .syntax--punctuation.syntax--separator {
     color: @syntax-text-color;
   }
-  .numeric {
+  .syntax--numeric {
     color: @cyan;
   }
-  .punctuation.section.regexp {
+  .syntax--punctuation.syntax--section.syntax--regexp {
     color: @red;
   }
-  .string.interpolated {
+  .syntax--string.syntax--interpolated {
     color: @cyan;
   }
-  .string.interpolated {
-    .embedded.line.ruby {
-      .punctuation {
-        .source.ruby {
+  .syntax--string.syntax--interpolated {
+    .syntax--embedded.syntax--line.syntax--ruby {
+      .syntax--punctuation {
+        .syntax--source.syntax--ruby {
           color: @red;
         }
       }
-      .source.ruby {
-        .punctuation.array,
-        .punctuation.function {
+      .syntax--source.syntax--ruby {
+        .syntax--punctuation.syntax--array,
+        .syntax--punctuation.syntax--function {
           color: @syntax-text-color;
         }
         color: @syntax-text-color;
       }
     }
   }
-  .support.function {
+  .syntax--support.syntax--function {
     color: @syntax-text-color;
   }
-  .support.function.kernel {
+  .syntax--support.syntax--function.syntax--kernel {
     color: @green;
   }
 }

--- a/styles/languages/scala.less
+++ b/styles/languages/scala.less
@@ -1,78 +1,78 @@
-.source.scala {
-  .variable {
+.syntax--source.syntax--scala {
+  .syntax--variable {
     color: @syntax-emphasized-color;
   }
 
-  .declaration {
+  .syntax--declaration {
     color: @syntax-emphasized-color;
     font-weight: bold;
   }
-  .comparison {
+  .syntax--comparison {
     color: @syntax-emphasized-color;
   }
-  .class, .type {
+  .syntax--class, .syntax--type {
     color: @yellow;
   }
-  .val {
+  .syntax--val {
     font-weight: normal;
   }
-  .variable {
+  .syntax--variable {
     font-weight: bold;
   }
-  .variable.parameter {
+  .syntax--variable.syntax--parameter {
     color: @violet;
     font-weight: normal;
   }
-  .control.flow {
+  .syntax--control.syntax--flow {
     color: @syntax-emphasized-color;
     font-weight: bold;
   }
-  .constant.language {
+  .syntax--constant.syntax--language {
     color: @syntax-emphasized-color;
     font-weight: bold;
   }
-  .function.declaration {
+  .syntax--function.syntax--declaration {
     color: @violet;
   }
-  .modifier.other {
+  .syntax--modifier.syntax--other {
     font-weight: bold;
   }
-  .package {
+  .syntax--package {
     color: @syntax-emphasized-color;
   }
-  .variable.import {
+  .syntax--variable.syntax--import {
     font-weight: normal;
   }
 
-  .type {
-    .bounds, .class {
+  .syntax--type {
+    .syntax--bounds, .syntax--class {
       color: @violet;
     }
   }
 
-  .documentation {
-    :not(.embedded) {
+  .syntax--documentation {
+    :not(.syntax--embedded) {
       // out of scope ?
-      // https://github.com/atom/link
-      &.link.entity {
+      // https://github.syntax--com/atom/link
+      &.syntax--link.syntax--entity {
         color: @blue;
         text-decoration: underline;
       }
-      .class, .parameter {
+      .syntax--class, .syntax--parameter {
         color: @syntax-emphasized-color;
       }
-      .description {
+      .syntax--description {
         color: @syntax-comment-color;
       }
     }
   }
 
-  .embedded {
+  .syntax--embedded {
     color: darken(@syntax-emphasized-color, 15%);
 
     // so we dont confused it with normal expressions
     font-style: italic;
-    .margin, .delimiters {
+    .syntax--margin, .syntax--delimiters {
       font-style: normal;
     }
   }


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai