### PR TITLE
add coffee embedded source style

### DIFF
--- a/styles/languages/coffee.less
+++ b/styles/languages/coffee.less
@@ -44,6 +44,9 @@
   .syntax--punctuation.syntax--section.syntax--embedded {
     color: @red;
   }
+  .syntax--embedded.syntax--source {
+    color: @syntax-text-color;
+  }
 
   .syntax--constant.syntax--numeric {
     color: @magenta;


### PR DESCRIPTION
Fix string interpolation in coffeescript:

Before:
![screen shot 2016-10-18 at 11 57 37 am](https://cloud.githubusercontent.com/assets/1993929/19487945/759a2f0a-952a-11e6-904d-ab40860b5687.png)

After:
![screen shot 2016-10-18 at 11 57 10 am](https://cloud.githubusercontent.com/assets/1993929/19487946/75f888c0-952a-11e6-9229-bc95d7aed8f1.png)
