### PR TITLE
increase contrast for background color of selections

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -6,7 +6,7 @@
 // General colors
 @syntax-text-color: @base0;
 @syntax-cursor-color: @base3;
-@syntax-selection-color: @base02;
+@syntax-selection-color: @base2;
 @syntax-selection-flash-color: @base1;
 @syntax-background-color: @base03;
 

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -6,7 +6,7 @@
 // General colors
 @syntax-text-color: @base0;
 @syntax-cursor-color: @base3;
-@syntax-selection-color: @base2;
+@syntax-selection-color: lighten(@base02, 1%);
 @syntax-selection-flash-color: @base1;
 @syntax-background-color: @base03;
 


### PR DESCRIPTION
### Description of the Change

I really love the dark colorized syntax theme. There is however drawback in my opinion and that's too little contrast between the normal background color and that of selections. It makes it very hard to discern where selections start and stop, esp. when doing multi-cursor selections. 

### Alternate Designs

The current selection background color seems to be "dictated" by Solarized. Solarized does not provide alternatives. I see this as a shortcoming in Solarized.

### Benefits

Selected characters and lines stand out very very well.

### Possible Drawbacks

This change might divert from Solarized's concepts.
