### PR TITLE
fix var, functions and method calls coloring in javascript

### DIFF
--- a/styles/syntax/javascript.less
+++ b/styles/syntax/javascript.less
@@ -36,6 +36,18 @@
   }
 
   .syntax--variable {
+    color: @syntax-text-color;
+  }
+  .syntax--variable.syntax--dom {
+    color: @green;
+  }
+  .syntax--delimiter + .syntax--dom {
+    color: @syntax-text-color;
+  }
+  .syntax--name {
+    color: @syntax-text-color;
+  }
+  .syntax--variable.syntax--language {
     color: @blue;
   }
   .syntax--variable.syntax--parameter {
@@ -47,10 +59,13 @@
   }
 
   .syntax--support.syntax--function {
-    color: @violet;
+    color: @syntax-text-color;
   }
   .syntax--support.syntax--constant {
     color: @syntax-text-color;
+  }
+  .syntax--storage {
+    color: @blue;
   }
 
   .syntax--constant.syntax--numeric {
@@ -68,6 +83,10 @@
     color: @blue;
   }
   .syntax--meta.syntax--brace.syntax--curly {
+    color: @blue;
+  }
+  .syntax--definition.syntax--begin.syntax--curly,
+  .syntax--definition.syntax--end.syntax--curly, {
     color: @blue;
   }
   .syntax--string.syntax--quoted.syntax--template {


### PR DESCRIPTION
### Description of the Change

Changed javascript coloring of "var", "function" (and their curly braces), method calls and speciall dom functions to match [official colors](http://ethanschoonover.com/solarized/img/screen-javascript-dark.png) 

Before:
![screen shot 2017-10-24 at 3 53 12 pm](https://user-images.githubusercontent.com/1993929/31967823-a9011218-b8d4-11e7-97b4-9e5c1fa0bb63.png)

After:
![screen shot 2017-10-24 at 3 57 02 pm](https://user-images.githubusercontent.com/1993929/31967824-a917fa1e-b8d4-11e7-83ad-df2777d1b38c.png)