### PR TITLE
Less language variable declaration highlighting

### DIFF
--- a/index.less
+++ b/index.less
@@ -14,9 +14,11 @@
 @import "styles/syntax/go.less";
 @import "styles/syntax/java.less";
 @import "styles/syntax/javascript.less";
+@import "styles/syntax/less.less";
 @import "styles/syntax/markdown.less";
 @import "styles/syntax/markup.less";
 @import "styles/syntax/php.less";
 @import "styles/syntax/python.less";
 @import "styles/syntax/ruby.less";
 @import "styles/syntax/scala.less";
+@import "styles/syntax/scss.less";

--- a/styles/syntax/css.less
+++ b/styles/syntax/css.less
@@ -1,5 +1,4 @@
 .syntax--source.syntax--css {
-
   .syntax--punctuation {
     &.syntax--separator,
     &.syntax--terminator {
@@ -47,17 +46,5 @@
 
   .syntax--keyword.syntax--important {
     color: @red;
-  }
-
-}
-
-
-// Less/Sass should have their own files,
-// but for just a single override, here should be fine too
-
-.syntax--source.syntax--less,
-.syntax--source.syntax--scss {
-  .syntax--keyword.syntax--unit {
-    color: @cyan;
   }
 }

--- a/styles/syntax/less.less
+++ b/styles/syntax/less.less
@@ -1,4 +1,8 @@
 .syntax--source.syntax--less {
+  .syntax--variable {
+    color: @blue;
+  }
+
   .syntax--keyword.syntax--unit {
     color: @cyan;
   }

--- a/styles/syntax/less.less
+++ b/styles/syntax/less.less
@@ -1,0 +1,5 @@
+.syntax--source.syntax--less {
+  .syntax--keyword.syntax--unit {
+    color: @cyan;
+  }
+}

--- a/styles/syntax/scss.less
+++ b/styles/syntax/scss.less
@@ -1,0 +1,5 @@
+.syntax--source.syntax--scss {
+  .syntax--keyword.syntax--unit {
+    color: @cyan;
+  }
+}


### PR DESCRIPTION
### Description of the Change

Less variable declarationss are not highlighted:
![image](https://user-images.githubusercontent.com/238929/40511462-ff010c02-5f5c-11e8-8039-3d2597651ac7.png)

In looking at the syntax highlighting in vim, I noticed that Less variable declarations are highlighted in blue:
![image](https://user-images.githubusercontent.com/238929/40511501-26120094-5f5d-11e8-8657-f2a4122b76dd.png)

This pull request adds blue highlighting for less variables, like:
![image](https://user-images.githubusercontent.com/238929/40511623-84565b8c-5f5d-11e8-8b30-fbd513a9a066.png)

_As a side note, there was one less/scss override in css.less with a note that later we should have separate files for those two languages. I created those files and applied the variable change only to the less context._

### Alternate Designs

No alternate designs. I understand that this project aims to follow vim highlighting where applicable.

### Benefits

You can easily distinguish less variable declarations.

### Possible Drawbacks

None.

### Applicable Issues

None. (_Should I create one?_)
