### PR TITLE
Style imports as solarized orange

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,4 +1,3 @@
-
 // Solarized Syntax Theme
 
 @import "styles/syntax-variables.less";
@@ -20,3 +19,4 @@
 @import "styles/syntax/python.less";
 @import "styles/syntax/ruby.less";
 @import "styles/syntax/scala.less";
+@import "styles/syntax/typescript.less";

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -1,4 +1,3 @@
-
 .syntax--comment {
   color: @syntax-comment-color;
   font-style: italic;
@@ -34,6 +33,13 @@
 
 .syntax--keyword {
   color: @green;
+
+  &.syntax--control {
+    &.syntax--import,
+    &.syntax--from {
+      color: @red;
+    }
+  }
 }
 
 .syntax--storage {

--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -33,13 +33,6 @@
 
 .syntax--keyword {
   color: @green;
-
-  &.syntax--control {
-    &.syntax--import,
-    &.syntax--from {
-      color: @red;
-    }
-  }
 }
 
 .syntax--storage {

--- a/styles/syntax/javascript.less
+++ b/styles/syntax/javascript.less
@@ -86,7 +86,7 @@
     color: @blue;
   }
   .syntax--definition.syntax--begin.syntax--curly,
-  .syntax--definition.syntax--end.syntax--curly, {
+  .syntax--definition.syntax--end.syntax--curly {
     color: @blue;
   }
   .syntax--string.syntax--quoted.syntax--template {
@@ -99,6 +99,12 @@
   }
   &.syntax--embedded .syntax--entity.syntax--name.syntax--tag {
     color: @blue;
+  }
+
+  .syntax--import {
+    .syntax--control {
+      color: @orange;
+    }
   }
 }
 .syntax--source.syntax--js.syntax--jsx {

--- a/styles/syntax/typescript.less
+++ b/styles/syntax/typescript.less
@@ -1,0 +1,7 @@
+.syntax--source.syntax--ts {
+  .syntax--import {
+    .syntax--control {
+      color: @orange;
+    }
+  }
+}


### PR DESCRIPTION
### Description of the Change

In looking at the [Solarized Home Page](http://ethanschoonover.com/solarized), I noticed that imports are usually orange (or in Haskell's case, magenta). Given that ES6 and TypeScript use imports as well, I thought that it would be nice to have support for that in this atom theme.

### Alternate Designs

_None._

### Benefits

Contrast between code and imports.

### Possible Drawbacks

_None._

### Applicable Issues

_None._
