### PR TITLE
Color typescript types yellow

### DIFF
--- a/styles/syntax/typescript.less
+++ b/styles/syntax/typescript.less
@@ -5,8 +5,14 @@
     }
   }
 
-  .syntax--entity.syntax--name.syntax--type {
-    color: @yellow;
+  .syntax--entity {
+    &.syntax--name.syntax--type {
+      color: @yellow;
+    }
+
+    &.syntax--inherited-class {
+      color: @yellow;
+    }
   }
 
   .syntax--support.syntax--type {

--- a/styles/syntax/typescript.less
+++ b/styles/syntax/typescript.less
@@ -4,4 +4,12 @@
       color: @orange;
     }
   }
+
+  .syntax--entity.syntax--name.syntax--type {
+    color: @yellow;
+  }
+
+  .syntax--support.syntax--type {
+    color: @yellow;
+  }
 }


### PR DESCRIPTION
### Description of the Change

Coloring TypeScript types as solarized yellow.

In looking at how solarized normally styles "types", I noticed that the type coloring for TypeScript in atom was inconsistent.

Here's atom latest:
![solarized-dark-ts-types-before](https://user-images.githubusercontent.com/238929/40551050-1df8092a-5ff9-11e8-9749-862b2a98897b.png)

You can see that primitive types get the green color while other types (whether interface or class) get a blue color. These really ought to be yellow.

Changes made in this pull request:
![solarized-dark-ts-types-after](https://user-images.githubusercontent.com/238929/40551103-42ef9360-5ff9-11e8-909f-fb3949410276.png)
 

### Alternate Designs

None.

### Benefits

Consistent type coloring for TypeScript.

### Possible Drawbacks

Some users might want primitive types and other types to be different.

### Applicable Issues

None.