### PR TITLE
language-markdown support

### DIFF
--- a/styles/syntax/markdown.less
+++ b/styles/syntax/markdown.less
@@ -1,3 +1,4 @@
+.syntax--md,
 .syntax--gfm {
   .syntax--link .syntax--entity {
     color: @violet;


### PR DESCRIPTION
### Description of the Change

This adds `language-markdown` support.

### Alternate Designs

Currently it just adds the `syntax--md` selector in addition to `syntax--gfm`. There could be more specific support.

### Benefits

Better highlighting for the `language-markdown` package.

### Possible Drawbacks

Harder to maintain two "markdown" packages.

### Applicable Issues

Closes #87
