### PR TITLE
Fix Tree-Sitter JavaScript highlighting for JSX file

### DIFF
--- a/styles/syntax/_base.less
+++ b/styles/syntax/_base.less
@@ -40,6 +40,10 @@
   color: @green;
 }
 
+.syntax--meta.syntax--class {
+  color: @blue;
+}
+
 .syntax--entity {
   &.syntax--name {
     &.syntax--class,

--- a/styles/syntax/javascript.less
+++ b/styles/syntax/javascript.less
@@ -1,8 +1,4 @@
 .syntax--source.syntax--js {
-  .syntax--constant {
-    color: @green;
-  }
-
   .syntax--comma {
     color: @syntax-text-color;
   }
@@ -10,13 +6,28 @@
   .syntax--support.syntax--class {
     color: @green;
   }
+  
+  .syntax--entity {
+    &.syntax--name.syntax--type {
+      color: @yellow;
+    }
+    &.syntax--name {
+      color: @syntax-text-color;
+      
+      &.syntax--function {
+        color: @blue;
+      }
+    }
+    
+    &.syntax--name.syntax--tag {
+      color: @blue;
+    }
+    
+    &.syntax--other.syntax--attribute-name {
+      color: @yellow;
+    }
+  }
 
-  .syntax--entity.syntax--name.syntax--type {
-    color: @yellow;
-  }
-  .syntax--entity.syntax--name {
-    color: @syntax-text-color;
-  }
 
   .syntax--meta.syntax--brace {
     color: @syntax-text-color;
@@ -29,7 +40,7 @@
     color: @green;
   }
   .syntax--keyword.syntax--control {
-    color: @green;
+    color: @orange;
   }
   .syntax--keyword.syntax--control.syntax--regexp {
     color: @cyan;
@@ -64,12 +75,9 @@
   .syntax--support.syntax--constant {
     color: @syntax-text-color;
   }
-  .syntax--storage {
-    color: @blue;
-  }
-
-  .syntax--constant.syntax--numeric {
-    color: @syntax-text-color;
+  
+  .syntax--storage.syntax--modifier {
+    color: @yellow;
   }
 
   .syntax--punctuation.syntax--terminator.syntax--statement {
@@ -85,10 +93,7 @@
   .syntax--meta.syntax--brace.syntax--curly {
     color: @blue;
   }
-  .syntax--definition.syntax--begin.syntax--curly,
-  .syntax--definition.syntax--end.syntax--curly {
-    color: @blue;
-  }
+  
   .syntax--string.syntax--quoted.syntax--template {
     .syntax--embedded.syntax--source {
       color: @syntax-text-color;
@@ -97,6 +102,7 @@
       }
     }
   }
+  
   &.syntax--embedded .syntax--entity.syntax--name.syntax--tag {
     color: @blue;
   }
@@ -105,10 +111,5 @@
     .syntax--control {
       color: @orange;
     }
-  }
-}
-.syntax--source.syntax--js.syntax--jsx {
-  .syntax--entity.syntax--name.syntax--tag {
-    color: @blue;
   }
 }


### PR DESCRIPTION
This should also apply to standard JavaScript files, but specifically, 
JSX syntax highlighting has been struggling.

### Description of the Change

As noted in #100, there's a lot of highlighting missing when Tree-Sitter is enabled for JavaScript. The focus of this PR is to address many of those changes and provide much needed color. It doesn't fix everything perfectly. In atom/language-javascript, there's an issue (https://github.com/atom/language-javascript/issues/618) that covers adding highlighting back for language keywords (such as `this` and `super`).

#### Before

![46153660-356c1400-c239-11e8-91ef-27a6720e3df4](https://user-images.githubusercontent.com/238929/47947451-5da6fc80-dee2-11e8-89ae-bdd5d1e95986.png)

#### After

<img width="807" alt="screen shot 2018-11-02 at 8 43 24 pm" src="https://user-images.githubusercontent.com/238929/47947444-3f410100-dee2-11e8-8331-5b889e7c053a.png">

### Alternate Designs

None.

### Benefits

JavaScript highlighting is improved.

### Possible Drawbacks

None.

### Applicable Issues

#100 
