### PR TITLE
Migration to core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/solarized-dark-syntax), please direct all issues and pull requests there in the future!
+
+---
+
 # Solarized Dark Syntax theme
 
 Atom theme using the ever popular dark [solarized](http://ethanschoonover.com/solarized) colors.


### PR DESCRIPTION
As of https://github.com/atom/atom/pull/18555, the `solarized-dark-syntax` package is now a part of the core Atom repository. This pull request updates `README.md` to reflect that fact. We'll be archiving this repository shortly.

/cc atom/atom#18280